### PR TITLE
chore: force Renovate to use semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommits"
   ]
 }


### PR DESCRIPTION
This should happen automatically but force it as doesn't appear to be
working at the moment.
